### PR TITLE
Replaced the possible dangerous option to not include tags with a leg…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Per default the graphite tag support (available since graphite 1.1) is enabled (
             # Prefix for all metrics sent to Graphite.
             metric-name-prefix = "kamon-graphite"
     
-            # include tags as suffix to metric name (format graphite 1.1) metricname;tag1=value1;tag2=value2
-            # without this enabled you might get multiple values for the same metric! - but may be necessary for legacy applications
-            include-tags = true
+            # instead of adding tags as suffix to metric name (format graphite 1.1) metricname;tag1=value1;tag2=value2
+            # the metric will be named metricname.tag1.value1.tag2.value2
+            legacy-support = false
     
             additional-tags {
                 service = "yes"
@@ -63,4 +63,5 @@ Main
 When sending metrics at a tick interval fails the current snapshot will be dropped and the next snapshot will try to send metrics using new connection.
     
 ## Possible enhancements
-* configure percentiles - currently hardcoded to 50,90,99
+* configure percentiles - currently hardcoded to 90
+* add tests

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,9 +11,10 @@ kamon{
         # Prefix for all metrics sent to Graphite.
         metric-name-prefix = "kamon-graphite"
 
-        # include tags as suffix to metric name (format graphite 1.1) metricname;tag1=value1;tag2=value2
-        # without this enabled you might get multiple values for the same metric! - but may be necessary for legacy applications
-        include-tags = true
+        # instead of adding tags as suffix to metric name (format graphite 1.1) metricname;tag1=value1;tag2=value2
+        # the metric will be named metricname.tag1.value1.tag2.value2
+        # this is useful for older graphite versions (prior to 1.1) without tagging support
+        legacy-support = false
 
         additional-tags {
             service = "yes"


### PR DESCRIPTION
…acy support that creates a metricname.tag1.value1.tag2.value2 for graphite prior to 1.1